### PR TITLE
[app-emulation/kubler] Rename dependency libpod to podman

### DIFF
--- a/app-emulation/kubler/kubler-0.9.6.ebuild
+++ b/app-emulation/kubler/kubler-0.9.6.ebuild
@@ -25,7 +25,7 @@ SLOT="0"
 DEPEND=""
 RDEPEND="dev-vcs/git
          docker? ( app-emulation/docker app-misc/jq )
-         podman? ( app-emulation/libpod )
+         podman? ( app-emulation/podman )
          rlwrap? ( app-misc/rlwrap )"
 
 src_install() {

--- a/app-emulation/kubler/kubler-9999.ebuild
+++ b/app-emulation/kubler/kubler-9999.ebuild
@@ -25,7 +25,7 @@ SLOT="0"
 DEPEND=""
 RDEPEND="dev-vcs/git
          docker? ( app-emulation/docker app-misc/jq )
-         podman? ( app-emulation/libpod )
+         podman? ( app-emulation/podman )
          rlwrap? ( app-misc/rlwrap )"
 
 src_install() {

--- a/app-emulation/kubler/metadata.xml
+++ b/app-emulation/kubler/metadata.xml
@@ -9,7 +9,7 @@
 	</longdescription>
 	<use>
 		<flag name="docker">Support Docker as build engine</flag>
-		<flag name="podman">Support libpod as build engine</flag>
+		<flag name="podman">Support podman as build engine</flag>
 		<flag name="rlwrap">Optional rlwrap support for input history</flag>
 	</use>
 	<upstream>


### PR DESCRIPTION
Upstream renamed their repo to podman and gentoo aligned with that:
- https://bugs.gentoo.org/765844
- https://podman.io/blogs/2020/07/07/repo-rename.html